### PR TITLE
Updated DynamicClassContextPool

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "libffi_iOS",
-        "repositoryURL": "https://github.com/623637646/libffi.git",
-        "state": {
-          "branch": null,
-          "revision": "c006945112296b8dc4c47bf70cd3ad5fc31488cf",
-          "version": "3.3.6-iOS"
-        }
+  "pins" : [
+    {
+      "identity" : "libffi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/623637646/libffi.git",
+      "state" : {
+        "revision" : "ba435e5a3b38cf2eede5974d3e2bd3c737f066e1",
+        "version" : "3.4.7"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/SwiftHook/Classes/Hook/DynamicClass.swift
+++ b/SwiftHook/Classes/Hook/DynamicClass.swift
@@ -10,7 +10,7 @@ import Foundation
 
 private let prefix = "SwiftHook_"
 
-private class DynamicClassContext: Hashable {
+private class DynamicClassContext {
     
     private static var byDynamicClass: [ObjectIdentifier: DynamicClassContext] = [:]
     private static var byClass: [ObjectIdentifier: DynamicClassContext] = [:]

--- a/SwiftHookTests/Components/DynamicClassTests.swift
+++ b/SwiftHookTests/Components/DynamicClassTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class DynamicClassTests: XCTestCase {
     
-    let InternalWrapDynamicClass = 69
-    let InternalUnwrapNonDynamicClass = 90
+    let InternalWrapDynamicClass = 81
+    let InternalUnwrapNonDynamicClass = 100
     
     func testNormal() {
         do {


### PR DESCRIPTION
This code improves the performances to check whether a class is a dynamic class.

When creating a DynamicClassContext it is saved in in two dicts, one by baseClass ObjectIdentifier and one by dynamicClass ObjectIdentifier:

```
var byDynamicClass: [ObjectIdentifier: DynamicClassContext]
var byBaseClass: [ObjectIdentifier: DynamicClassContext]
```

`ObjectIdentifier(someClass)` is a pointer to a class and is blazing fast.

So it's very fast to check if a class is a dynamic class `byDynamicClass[ObjectIdentifier(dynamicClass)] != nil` 

or if there is already a DynamicClassContext for a base class `let existingContext = byBaseClass[ObjectIdentifier(baseClass)]`.