### PR TITLE
Improved Associated Object Values

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "libffi_iOS",
-        "repositoryURL": "https://github.com/623637646/libffi.git",
-        "state": {
-          "branch": null,
-          "revision": "c006945112296b8dc4c47bf70cd3ad5fc31488cf",
-          "version": "3.3.6-iOS"
-        }
+  "pins" : [
+    {
+      "identity" : "libffi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/623637646/libffi.git",
+      "state" : {
+        "revision" : "ba435e5a3b38cf2eede5974d3e2bd3c737f066e1",
+        "version" : "3.4.7"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }

--- a/SwiftHook/Classes/Hook/HookDeallocAfterDelegate.swift
+++ b/SwiftHook/Classes/Hook/HookDeallocAfterDelegate.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-private var associatedDelegateHandle: UInt8 = 0
-
 private class HookDeallocAfterDelegate {
     
     var hookClosures = [AnyObject]()
@@ -39,11 +37,7 @@ private struct HookDeallocAfterToken: Token {
 }
 
 func hookDeallocAfterByDelegate(object: AnyObject, closure: AnyObject) -> Token {
-    var delegate: HookDeallocAfterDelegate! = objc_getAssociatedObject(object, &associatedDelegateHandle) as? HookDeallocAfterDelegate
-    if delegate == nil {
-        delegate = HookDeallocAfterDelegate()
-        objc_setAssociatedObject(object, &associatedDelegateHandle, delegate, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-    }
+    let delegate = getAssociatedValue("associatedDelegateHandle", object: object, initialValue: HookDeallocAfterDelegate())
     delegate.hookClosures.append(closure)
     return HookDeallocAfterToken.init(delegate: delegate, closure: closure)
 }

--- a/SwiftHook/Classes/Hook/InsteadHookClosureExtension.swift
+++ b/SwiftHook/Classes/Hook/InsteadHookClosureExtension.swift
@@ -11,8 +11,6 @@ import Foundation
 import SwiftHookOCSources
 #endif
 
-private var associatedInsteadContextHandle: UInt8 = 0
-
 class InsteadContext {
     let objectPointer: UnsafeMutableRawPointer
     let selectorPointer: UnsafeMutableRawPointer
@@ -29,13 +27,10 @@ func createInsteadClosure(targetIMP: IMP, objectPointer: UnsafeMutableRawPointer
     let insteadClosure: (@convention(block) () -> Void) = {}
     sh_setBlockInvoke(insteadClosure, targetIMP)
     let insteadContext = InsteadContext.init(objectPointer: objectPointer, selectorPointer: selectorPointer, currentHookClosure: currentHookClosure)
-    objc_setAssociatedObject(insteadClosure, &associatedInsteadContextHandle, insteadContext, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    setAssociatedValue(insteadContext, key: "associatedInsteadContextHandle", object: insteadClosure as AnyObject)
     return insteadClosure as AnyObject
 }
 
 func getInsteadContext(insteadClosure: AnyObject) -> InsteadContext? {
-    guard let insteadContext = objc_getAssociatedObject(insteadClosure, &associatedInsteadContextHandle) as? InsteadContext else {
-        return nil
-    }
-    return insteadContext
+    getAssociatedValue("associatedInsteadContextHandle", object: insteadClosure)
 }

--- a/SwiftHook/Classes/Hook/KVOWrapper.swift
+++ b/SwiftHook/Classes/Hook/KVOWrapper.swift
@@ -114,9 +114,8 @@ func isWrappedKVO(object: NSObject) -> Bool {
     return object.swiftHookObserver != nil
 }
 
-private var isSupportedKVOAssociatedKey = 0
 func isSupportedKVO(object: NSObject) throws -> Bool {
-    if let isSupportedKVO = objc_getAssociatedObject(object, &isSupportedKVOAssociatedKey) as? Bool {
+    if let isSupportedKVO: Bool = getAssociatedValue("isSupportedKVO", object: object) {
         return isSupportedKVO
     }
     guard let isaClass = object_getClass(object) else {
@@ -141,7 +140,7 @@ func isSupportedKVO(object: NSObject) throws -> Bool {
             result = false
         }
     }
-    objc_setAssociatedObject(object, &isSupportedKVOAssociatedKey, result, .OBJC_ASSOCIATION_COPY_NONATOMIC)
+    setAssociatedValue(result, key: "isSupportedKVO", object: object)
     return result
 }
 
@@ -171,13 +170,12 @@ func isKVOed(object: NSObject) throws -> Bool {
 // MARK: extension
 
 private extension NSObject {
-    static var swiftHookObserverAssociatedKey = 0
     var swiftHookObserver: Observer? {
         get {
-            return objc_getAssociatedObject(self, &NSObject.swiftHookObserverAssociatedKey) as? Observer
+            getAssociatedValue("swiftHookObserver", object: self)
         }
         set {
-            objc_setAssociatedObject(self, &NSObject.swiftHookObserverAssociatedKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            setAssociatedValue(newValue, key: "swiftHookObserver", object: self)
         }
     }
 }

--- a/SwiftHook/Classes/Utilities/AssociatedValue.swift
+++ b/SwiftHook/Classes/Utilities/AssociatedValue.swift
@@ -1,0 +1,31 @@
+//
+//  AssociatedValue.swift
+//  SwiftHook
+//
+//  Created by Florian Zand on 05.05.25.
+//
+
+import Foundation
+
+func getAssociatedValue<T>(_ key: String, object: AnyObject) -> T? {
+    objc_getAssociatedObject(object, key.address) as? T
+}
+
+func getAssociatedValue<T>(_ key: String, object: AnyObject, initialValue: @autoclosure () -> T) -> T {
+    getAssociatedValue(key, object: object) ?? setAndReturn(initialValue(), key: key, object: object)
+}
+
+func setAssociatedValue<T>(_ value: T?, key: String, object: AnyObject) {
+    objc_setAssociatedObject(object, key.address, value, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+}
+
+private func setAndReturn<T>(_ value: T, key: String, object: AnyObject) -> T {
+    objc_setAssociatedObject(object, key.address, value, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    return value
+}
+
+fileprivate extension String {
+    var address: UnsafeRawPointer {
+        UnsafeRawPointer(bitPattern: abs(hashValue))!
+    }
+}


### PR DESCRIPTION
Cleaner code for getting and setting associated object values using:

```
getAssociatedValue(key:object:)
getAssociatedValue(key:object:initialValue:)
setAssociatedValue(_:key:object:)
```